### PR TITLE
Added --broadcast-whitelist option

### DIFF
--- a/comet/service/broker.py
+++ b/comet/service/broker.py
@@ -209,6 +209,6 @@ def makeService(config):
         remote_service.setServiceParent(broker_service)
 
     if not broker_service.services:
-        reactor.callWhenRunning(log.warning, "No services requested; stopping.")
+        reactor.callWhenRunning(log.warn, "No services requested; stopping.")
         reactor.callWhenRunning(reactor.stop)
     return broker_service

--- a/comet/utility/__init__.py
+++ b/comet/utility/__init__.py
@@ -5,4 +5,5 @@ from comet.utility.event_db import *
 from comet.utility.options import *
 from comet.utility.voevent import *
 from comet.utility.whitelist import *
+from comet.utility.broadcaster_whitelist import *
 from comet.utility.xml import *

--- a/comet/utility/broadcaster_whitelist.py
+++ b/comet/utility/broadcaster_whitelist.py
@@ -1,0 +1,21 @@
+# Comet VOEvent Broker.
+# IP whitelisting factory.
+
+from ipaddress import ip_address
+from twisted.protocols.policies import WrappingFactory
+import comet.log as log
+
+__all__ = ["BroadcasterWhitelistingFactory"]
+
+class BroadcasterWhitelistingFactory(WrappingFactory):
+    def __init__(self, wrappedFactory, whitelist):
+        self.whitelist = whitelist
+        WrappingFactory.__init__(self, wrappedFactory)
+
+    def buildProtocol(self, addr):
+        remote_ip = ip_address(addr.host)
+        if any(remote_ip in network for network in self.whitelist):
+            return WrappingFactory.buildProtocol(self, addr)
+        else:
+            log.info("Attempted subscription from non-whitelisted %s" % str(addr))
+            return None


### PR DESCRIPTION
I added a new --broadcast-whitelist option that in principle is just a copy of --whitelist but works on the broadcaster, i.e. only hosts from a given network can subscribe to its events. It just denies clients to connect, so another Comet session with the --remote flag set to that broadcaster will try to connect forever (although in increasing intervals). This is not ideal, but I don't see a nice way around it.

I also fixed a minor but in broker.py, where log.warning is used instead of log.warn.