### PR TITLE
Bugfix: Fixup a few missed references to 'log.warning'.

### DIFF
--- a/comet/service/broker.py
+++ b/comet/service/broker.py
@@ -195,6 +195,6 @@ def makeService(config):
         remote_service.setServiceParent(broker_service)
 
     if not broker_service.services:
-        reactor.callWhenRunning(log.warning, "No services requested; stopping.")
+        reactor.callWhenRunning(log.warn, "No services requested; stopping.")
         reactor.callWhenRunning(reactor.stop)
     return broker_service

--- a/comet/validator/previously_seen.py
+++ b/comet/validator/previously_seen.py
@@ -24,7 +24,7 @@ class CheckPreviouslySeen(object):
                 raise Exception("Previously seen by this broker")
 
         def db_failure(failure):
-            log.warning("Event DB lookup failed!")
+            log.warn("Event DB lookup failed!")
             log.err(failure)
             return failure
 

--- a/scripts/comet-sendvo
+++ b/scripts/comet-sendvo
@@ -37,7 +37,7 @@ class OneShotSender(VOEventSenderFactory):
         reactor.stop()
 
     def clientConnectionFailed(self, connector, reason):
-        log.warning("Connection failed")
+        log.warn("Connection failed")
         reactor.stop()
 
 if __name__ == "__main__":
@@ -54,10 +54,10 @@ if __name__ == "__main__":
     try:
         factory = OneShotSender(xml_document(f.read()))
     except IOError:
-        log.warning("Reading XML document failed")
+        log.warn("Reading XML document failed")
         reactor.callWhenRunning(reactor.stop)
     except ElementTree.Error:
-        log.warning("Could not parse event text")
+        log.warn("Could not parse event text")
         reactor.callWhenRunning(reactor.stop)
     else:
         reactor.connectTCP(config['host'], config['port'], factory)


### PR DESCRIPTION
These have been replaced by log.warn, the 'warning' alias has been removed
and now results in an AttributeError.

This was causing comet-sendvo to hang rather than exit with an error
code if e.g. no broker-connection can be established.

Having just seen discussion  at #39 - I'm happy to assign copyright to you. 