### PR TITLE
Options to use UNIX domain sockets for broker or publisher

### DIFF
--- a/docs/usage/broker.rst
+++ b/docs/usage/broker.rst
@@ -45,8 +45,12 @@ provide a brief usage message::
                                     --receive and --broadcast)
         --eventdb=                  Event database root. [default: system dependent]
         --receive-port=             TCP port for receiving events. [default: 8098]
+        --receive-unix-socket=      Path to UNIX domain socket for receiving
+                                    events.
         --broadcast-port=           TCP port for broadcasting events. [default:
                                     8099]
+        --broadcast-unix-socket=    Path to UNIX domain socket for broadcasting
+                                    events.
         --broadcast-test-interval=  Interval between test event brodcasts (in
                                     seconds; 0 to disable). [default: 3600]
         --author-whitelist=         Network to be included in author whitelist.
@@ -55,6 +59,8 @@ provide a brief usage message::
                                     whitelist. [default: 0.0.0.0/0]
         --remote=                   Remote broadcaster to subscribe to
                                     (host[:port]).
+        --remote-unix-socket=       Path to UNIX domain socket for remote
+                                    broadcaster to subscribe to.
         --filter=                   XPath filter applied to events broadcast by
                                     remote.
         --cmd=                      Spawn external command on event receipt.

--- a/docs/usage/publisher.rst
+++ b/docs/usage/publisher.rst
@@ -13,6 +13,7 @@ message::
   Options:
     -h, --host=             Host to send to. [default: localhost]
     -p, --port=             Port to send to. [default: 8098]
+    -s, --unix-socket=      UNIX domain socket to send to.
     -f, --file=             Where to read XML text (- is stdin). [default: -]
         --version           Display Twisted version and exit.
         --help              Display this help and exit.

--- a/scripts/comet-sendvo
+++ b/scripts/comet-sendvo
@@ -24,6 +24,7 @@ class Options(usage.Options):
     optParameters = [
         ["host", "h", "localhost", "Host to send to."],
         ["port", "p", 8098, "Port to send to.", int],
+        ["unix-socket", "s", None, "UNIX domain socket to send to."],
         ["file", "f", "-", "Where to read XML text to send (- is stdin)."]
     ]
 
@@ -65,7 +66,10 @@ if __name__ == "__main__":
         log.warn("Could not parse event text")
         reactor.callWhenRunning(reactor.stop)
     else:
-        reactor.connectTCP(config['host'], config['port'], factory)
+        if config['unix-socket'] is None:
+            reactor.connectTCP(config['host'], config['port'], factory)
+        else:
+            reactor.connectUNIX(config['unix-socket'], factory)
     finally:
         f.close()
 


### PR DESCRIPTION
Add options to use UNIX domain sockets for all of the connection endpoints available to the broker or publisher.

We operate an instance of comet on a shared system in a computing cluster to which many users have access. When we were using TCP sockets, any local user could submit a VOEvent. Adding command line options to use UNIX domain sockets allows us to control submission access using filesystem permissions.