### PR TITLE
use os.pathsep instead of custom implementation

### DIFF
--- a/comet/utility/options.py
+++ b/comet/utility/options.py
@@ -2,7 +2,6 @@
 # Base class for command line options.
 
 import os
-import sys
 from argparse import ArgumentParser, ArgumentTypeError
 
 from lxml.etree import XPath, XPathSyntaxError
@@ -21,9 +20,8 @@ class BaseOptions(object):
         else:
             self.parser = ArgumentParser()
         if "COMET_PLUGINPATH" in os.environ:
-            split_on = ";" if sys.platform == "win32" else ":"
             comet.plugins.__path__.extend(
-                os.environ.get("COMET_PLUGINPATH").split(split_on)
+                os.environ.get("COMET_PLUGINPATH").split(os.pathsep)
             )
 
         self.parser.add_argument(


### PR DESCRIPTION
Hi, I was looking for ways to install plugins outside of `comet/plugins`, when I stumbled over #63. 
Looks like exactly what I need :D .. thanks for that!
(I wish it was possible to avoid such an env-var altogether and just detect plugins in all packages on a system, but I assume that is impossible performance wise? ... )

Anyway I think you can save a line and an import here  ... `os.pathsep` does exactly this for you already:
https://docs.python.org/3/library/os.html#os.pathsep